### PR TITLE
When creating users, use 'preferred_username' if 'user_name' can't be found

### DIFF
--- a/lib/redmine_openid_connect/account_controller_patch.rb
+++ b/lib/redmine_openid_connect/account_controller_patch.rb
@@ -105,7 +105,11 @@ module RedmineOpenidConnect
         if user.nil?
           user = User.new
 
-          user.login = user_info["user_name"]
+          if user_info["user_name"].present?
+            user.login = user_info["user_name"]
+          else
+            user.login = user_info["preferred_username"]
+          end
 
           attributes = {
             firstname: user_info["given_name"],


### PR DESCRIPTION
OpenID Connect specs say the username is 'preferred_username' not 'user_name' so let's go with the latter if we can't find 'user_name'.

This solves an issue where I was getting an error "Unable to create user  due to Login cannot be blank" in my Redmine 3.4.3 with no LDAP connection.