### PR TITLE
Stale Permissions - possible security issue #28

### DIFF
--- a/lib/redmine_openid_connect/account_controller_patch.rb
+++ b/lib/redmine_openid_connect/account_controller_patch.rb
@@ -117,7 +117,7 @@ module RedmineOpenidConnect
           user.assign_attributes attributes
 
           if user.save
-            user.update_attribute(:admin, true) if oic_session.admin?
+            user.update_attribute(:admin, oic_session.admin?)
             oic_session.user_id = user.id
             oic_session.save!
             successful_authentication(user)
@@ -130,7 +130,7 @@ module RedmineOpenidConnect
             return invalid_credentials
           end
         else
-          user.update_attribute(:admin, true) if oic_session.admin?
+          user.update_attribute(:admin, oic_session.admin?)
           oic_session.user_id = user.id
           oic_session.save!
           successful_authentication(user)


### PR DESCRIPTION
I dont have any Ruby skills, but I've tested this change in our production environment and it does what i  would expect. if the user gets his admin role revoked in the IDP it will be reflected in redmine upon the next login. 