### PR TITLE
Update oic_session.rb

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -162,7 +162,7 @@ class OicSession < ActiveRecord::Base
     if id_token?
       @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
     else  # keycloak way...
-      @user = JSON::parse(Base64::decode64(access_token.split('.')[1]))
+      @user = JSON::parse(Base64::urlsafe_decode64(access_token.split('.')[1]))
     end
     return @user
   end


### PR DESCRIPTION
Keycloak will encode the User info with url safe encoder using ‘-’ instead of ‘+’ and ‘_’ instead of ‘/’. When the base64encoded string contains '-' or '_' , orignal code will throw `500 JSON::ParserError`. This change will fix it.