### PR TITLE
adapt to new keycloak behaviour

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -162,10 +162,10 @@ class OicSession < ActiveRecord::Base
   end
 
   def user
-    if id_token?
-      @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
-    else  # keycloak way...
+    if access_token? # keycloak way...
       @user = JSON::parse(Base64::decode64(access_token.split('.')[1]))
+    else
+      @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
     end
     return @user
   end


### PR DESCRIPTION
This change should not break existing logic but just prefer access tokens if present new keycloak will provide ID tokens, but these dont contain needed info so prefer accesstokens if they are present