### PR TITLE
Added Support for login selector (external or sso); Added pt translation;

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -28,6 +28,10 @@ class OicSession < ActiveRecord::Base
     !self.enabled?
   end
 
+  def self.login_selector?
+    client_config['login_selector']
+  end
+
   def self.openid_configuration_url
     client_config['openid_connect_server_url'] + '/.well-known/openid-configuration'
   end

--- a/app/views/account/oic_local_logout.html.erb
+++ b/app/views/account/oic_local_logout.html.erb
@@ -1,3 +1,3 @@
 <p class="oic-logged-out">
-    <%= l(:oic_logout_success, oic_login_url).html_safe %>
+    <%= l(:oic_logout_success, home_url).html_safe %>
 </p>

--- a/app/views/hooks/redmine_openid_connect/_view_account_login_bottom.html.erb
+++ b/app/views/hooks/redmine_openid_connect/_view_account_login_bottom.html.erb
@@ -1,0 +1,7 @@
+<div id="login-form-openid">
+  <%= form_tag(oic_login_url, :method => :get) do %>
+  <%= back_url_hidden_field_tag %>
+
+  <input type="submit" name="login-openid" value="<%=l(:button_login_sso)%>" tabindex="5" id="login-submit-openid" />
+  <% end %>
+</div>

--- a/app/views/settings/_redmine_openid_connect_settings.html.erb
+++ b/app/views/settings/_redmine_openid_connect_settings.html.erb
@@ -44,3 +44,8 @@
   <label><%= t('config.disable_ssl_validation') %></label>
   <%= check_box_tag 'settings[disable_ssl_validation]', true, @settings['disable_ssl_validation'] %>
 </p>
+
+<p>
+  <label><%= t('config.login_selector') %></label>
+    <%= check_box_tag 'settings[login_selector]', false, @settings['login_selector'] %>
+</p>

--- a/assets/stylesheets/redmine_openid_connect.css
+++ b/assets/stylesheets/redmine_openid_connect.css
@@ -1,0 +1,14 @@
+#login-form-openid {
+    margin: 1em auto 2em auto;
+    padding: 20px;
+    width: 340px;
+    border: 1px solid #FDBF3B;
+    background-color: #FFEBC1;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+#login-form-openid input[type=submit] {
+    display: block;
+    width: 100%;
+}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,7 @@
 de:
   config:
     enabled: Aktiv
+    login_selector: Login-Auswahl
     header: OpenID Connect Konfiguration
     client_id: Client-ID
     openid_connect_server_url: OpenID Connect Server-Url
@@ -12,3 +13,4 @@ de:
   oic_logout_success: 'Sie wurden ausgeloggt. <a href="%{value}">Klicken Sie hier, um sich erneut einzuloggen</a>.'
   oic_cannot_create_user: "Der Benutzer %{value} konnte nicht angelegt werden: "
   oic_try_another_account: "<a href='%{value}'>Mit einem anderen Account einloggen.</a>"
+  button_login_sso: Melden Sie sich mit SSO an

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@
 en:
   config:
     enabled: Enabled
+    login_selector: Login Selector
     header: OpenID Connect Configuration
     client_id: Client ID
     openid_connect_server_url: OpenID Connect server url
@@ -13,3 +14,4 @@ en:
   oic_logout_success: 'You have been logged out. <a href="%{value}">Click here to log in again</a>.'
   oic_cannot_create_user: "Could no create the user %{value}: "
   oic_try_another_account: "<a href='%{value}'>Try logging in with another account</a>"
+  button_login_sso: Login with SSO

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,17 @@
+# Portuguese strings go here for Rails i18n
+pt:
+  config:
+    enabled: Ativado
+    login_selector: Seletor de login
+    header: "Configuração OpenID Connect"
+    client_id: Client ID
+    openid_connect_server_url: Url do servidor OpenID Connect
+    scopes: OpenID Connect scopes (separados por virgula)
+    client_secret: Client Secret
+    group: "Grupo autorizado (vazio se todos os utilizadores são autorizados)"
+    admin_group: "Grupo de Administradores (membros deste grupo são tratados como administradores)"
+    dynamic_config_expiry: "Com que frequência obter configuração do openid (padrão 1 dia)"
+  oic_logout_success: 'Saiu com sucesso. <a href="%{value}">Clique aqui para voltar a entrar</a>.'
+  oic_cannot_create_user: "Não foi possível criar o utilizador %{value}: "
+  oic_try_another_account: "<a href='%{value}'>Tente entrar com uma conta diferente</a>"
+  button_login_sso: Entrar com SSO

--- a/lib/redmine_openid_connect/account_controller_patch.rb
+++ b/lib/redmine_openid_connect/account_controller_patch.rb
@@ -2,7 +2,7 @@ module RedmineOpenidConnect
   module AccountControllerPatch
 
     def login
-      if OicSession.disabled? || params[:local_login].present? || request.post?
+      if OicSession.disabled? || OicSession.login_selector? || params[:local_login].present? || request.post?
         return super
       end
 

--- a/lib/redmine_openid_connect/application_controller_patch.rb
+++ b/lib/redmine_openid_connect/application_controller_patch.rb
@@ -1,7 +1,7 @@
 module RedmineOpenidConnect
   module ApplicationControllerPatch
     def require_login
-      return super unless OicSession.enabled?
+      return super unless (OicSession.enabled? && !OicSession.login_selector?)
 
       if !User.current.logged?
         if request.get?

--- a/lib/redmine_openid_connect/hooks.rb
+++ b/lib/redmine_openid_connect/hooks.rb
@@ -9,6 +9,21 @@ module RedmineOpenidConnect
       request.session
     end
 
+    def view_account_login_bottom(context={})
+      return unless (OicSession.enabled? && OicSession.login_selector?)
+      if context[:request].session[:oic_session_id].blank?
+        oic_session = OicSession.create
+      else
+        oic_session = OicSession.find context[:request].session[:oic_session_id]
+      end
+      context[:oic_session] = oic_session
+      context[:controller].send(:render_to_string, {
+        partial: 'hooks/redmine_openid_connect/view_account_login_bottom',
+        locals: context
+      })
+    rescue ActiveRecord::RecordNotFound => e
+    end
+
     def view_layouts_base_body_bottom(context={})
       return unless OicSession.enabled?
       oic_session = OicSession.find context[:request].session[:oic_session_id]
@@ -18,6 +33,10 @@ module RedmineOpenidConnect
         locals: context
       })
     rescue ActiveRecord::RecordNotFound => e
+    end
+
+    def view_layouts_base_html_head(context={})
+      stylesheet_link_tag(:redmine_openid_connect, :plugin => 'redmine_openid_connect')
     end
   end
 end


### PR DESCRIPTION
Hi 
I faced a situation using this plugin where both external users and domain users had to be able to login. Domain users can typically login using the OpenID provider however external users used to login directly with no domain entry. So I added the possibility of having a login selector where users can use the legacy redmine login or login directly through the OpenID provider.
Also added Portuguese translation as it will be used on that situation .

Added Support for login selector (external or sso); 
Added pt translation;