### PR TITLE
fix infinite redirect by clean up expired session

### DIFF
--- a/lib/redmine_openid_connect/application_controller_patch.rb
+++ b/lib/redmine_openid_connect/application_controller_patch.rb
@@ -1,15 +1,23 @@
 module RedmineOpenidConnect
   module ApplicationControllerPatch
     def require_login
-      return super unless (OicSession.enabled? && !OicSession.login_selector?)
-
-      if !User.current.logged?
+      if !User.current.logged? && OicSession.enabled? && OicSession.login_selector?
         if request.get?
           url = request.original_url
         else
           url = url_for(:controller => params[:controller], :action => params[:action], :id => params[:id], :project_id => params[:project_id])
         end
+        # this should fix infinite redirect
+        # because this plugin not reseting session when assigning logged user
+        # it should at least reset session when expired so it will not check every time
+        # which will cause infinite redirect
+        # also clean lingering oic sessio so that back_url still works
+        reset_session
         session[:remember_url] = url
+      end
+      return super unless (OicSession.enabled? && !OicSession.login_selector?)
+
+      if !User.current.logged?
         redirect_to oic_login_url
         return false
       end
@@ -18,7 +26,8 @@ module RedmineOpenidConnect
 
     # set the current user _without_ resetting the session first
     def logged_user=(user)
-      return super(user) unless OicSession.enabled?
+      # only override parent if the request is from ioc user
+      return super(user) unless session[:oic_session_id]
 
       if user && user.is_a?(User)
         User.current = user
@@ -29,3 +38,4 @@ module RedmineOpenidConnect
     end
   end # ApplicationControllerPatch
 end
+


### PR DESCRIPTION
Hi,

This should fix infinite redirect problem when session lifetime is set up on Redmine. 
From what I see the problem is after the session is expired, Redmine will redirect to login page because it detects the session is expired and on the login page it also check whether the client have any session and check if the session is expired or not, if it is it will redirect to login page and it will repeat it infinitely.
By default Redmine is clean up session if there any changes on user, in this case when the session is expired, Redmine should set the user as null which will reset the session, however since this plugin overwrite the `logged_user`, it does not clean up the session, that is why the expired user session will keep lingering and it cause the redirection.

What I do in this PR is just clean up the session when Redmine detect the session is expired (it will call `require_login`) and also call the default `logged_user` if the logged user is not ioc user. The second one is not mandatory but it can be a good guard if the system allow both oic user and Redmine internal user.

Please check it.

Best Regards,
Rangga