### PR TITLE
clean oic session older than 7 days

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -3,6 +3,7 @@ class OicSession < ActiveRecord::Base
 
   before_create :randomize_state!
   before_create :randomize_nonce!
+  before_create :clean_old_oic_with_null_user
 
   def self.client_config
     Setting.plugin_redmine_openid_connect
@@ -180,6 +181,10 @@ class OicSession < ActiveRecord::Base
       @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
     end
     return @user
+  end
+
+  def clean_old_oic_with_null_user
+    OicSession.where("user_id is null and updated_at < ?", 7.days.ago).delete_all
   end
 
   def authorization_url


### PR DESCRIPTION
Hi,

This should solve the problem where the oic_session is keep getting bigger and bigger.
The idea is before we create a new session for a user, it will clear up a week old session.
Please take a look

Cheers,