### PR TITLE
Fix 500 error when deleting users with existing OpenID sessions

### DIFF
--- a/db/migrate/001_create_oic_sessions.rb
+++ b/db/migrate/001_create_oic_sessions.rb
@@ -1,7 +1,8 @@
 class CreateOicSessions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :oic_sessions do |t|
-      t.references :user, foreign_key: true
+      t.references :user, foreign_key: { on_delete: :cascade }
+
       t.text :code
       t.string :state
       t.string :nonce


### PR DESCRIPTION
It is not possible to delete users that connected via OpenID because of the foreign key constraint. This patch will perform a cascade delete on the `oic_sessions` table.

Resolves #62 