### PR TITLE
Fix 500 error when the scope is an empty string

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -254,7 +254,7 @@ class OicSession < ActiveRecord::Base
   end
 
   def scopes
-    if client_config["scopes"].nil? 
+    if client_config["scopes"].blank?
       return "openid profile email user_name"
     else
       client_config["scopes"].split(',').each(&:strip).join(' ')


### PR DESCRIPTION
Fix `NoMethodError` exception when the `scopes` field is left blank.