### PR TITLE
Add source to Gemfile to avoid warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
+source 'https://rubygems.org'
 gem 'httparty', '~> 0.14.0'


### PR DESCRIPTION
Add a default source to the Gemfile to avoid deprecation warning

[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
Could not find gem 'httparty (~> 0.14.0)' in locally installed gems.

The source contains the following gems matching 'httparty':
  * httparty-0.20.0
