### PR TITLE
feat: use email as login as a fallback

### DIFF
--- a/lib/redmine_openid_connect/account_controller_patch.rb
+++ b/lib/redmine_openid_connect/account_controller_patch.rb
@@ -102,7 +102,7 @@ module RedmineOpenidConnect
 
           user = User.new
 
-          user.login = user_info["user_name"] || user_info["nickname"] || user_info["preferred_username"]
+          user.login = user_info["user_name"] || user_info["nickname"] || user_info["preferred_username"] || user_info["email"]
 
           firstname = user_info["given_name"]
           lastname = user_info["family_name"]


### PR DESCRIPTION
I added the email as a login fallback, in case, that no username field is found. This should work well when interfacing with Google OpenID.