### PR TITLE
Fix wrong target origin warning when certain browser extensions are installed

### DIFF
--- a/app/views/account/rpiframe.html.erb
+++ b/app/views/account/rpiframe.html.erb
@@ -21,6 +21,11 @@
 
     window.addEventListener("message", receiveMessage, false);
     function receiveMessage(e) {
+      // other scripts might use postMessage method, filter out events
+      // not originated from opiframe.
+      var opiframe = window.parent.document.getElementById("opiframe").contentWindow;
+      if (e.source !== opiframe) { return };
+
       if (e.origin !== target_origin) { return alert('Wrong target origin: ' + target_origin); }
       stat = e.data;
 


### PR DESCRIPTION
When certain browser extensions like MetaMask or Phantom installed, this plugin will display a popup with "Wrong target origin: XXX" message.

This PR fixed the issue by filtering out unrelated events in the check session event handler.