### PR TITLE
Remove unloadable

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -1,6 +1,4 @@
 class OicSession < ActiveRecord::Base
-  unloadable
-
   before_create :randomize_state!
   before_create :randomize_nonce!
 


### PR DESCRIPTION
This method is no longer valid with Rails 7.